### PR TITLE
Switch from nipype advanced to nipype level1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM miykael/nipype_advanced
+FROM miykael/nipype_level1
 MAINTAINER Carlos Correa <cgc@stanford.edu>
 
 # Make directory for flywheel spec (v0)


### PR DESCRIPTION
- [ ] QA on human
- [ ] QA on monkey
- [ ] document QA

alternatively, should we directly build off of neurdebian and install AFNI? It might only be a difference of a few lines. (will need to build off debian and add neurodebian as apt provider. see [here](https://github.com/nipy/nipype/blob/master/Dockerfile))